### PR TITLE
Fix deserialization of enums and add fuzzer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cbor-smol"
 version = "0.4.0"
 authors = ["Nicolas Stalder <n@stalder.io>"]
-edition = "2018"
+edition = "2021"
 description = "Streamlined serde serializer/deserializer for CBOR"
 repository = "https://github.com/nickray/cbor-smol"
 readme = "README.md"

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "cbor-smol-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1.2.3", features = ["derive"] }
+serde = { version = "1.0.152", features = ["derive"] }
+serde_bytes = "0.11.9"
+serde_cbor = "0.11.2"
+
+[dependencies.cbor-smol]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "fuzz_target_1"
+path = "fuzz_targets/fuzz_target_1.rs"
+test = false
+doc = false

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cbor-smol-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -1,0 +1,86 @@
+#![no_main]
+
+use arbitrary::{Arbitrary, Unstructured};
+use libfuzzer_sys::fuzz_target;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, PartialEq, Arbitrary, Serialize, Deserialize)]
+enum AllEnums {
+    I8(i8),
+    U8(u8),
+    I16(i16),
+    U16(u16),
+    I32(i32),
+    U32(u32),
+    // Not implemented
+    // I64(i64),
+    U64(u64),
+    Struct(Struct),
+    Array([Struct; 4]),
+    Option(Option<Struct>),
+    Vec(Vec<Struct>),
+    Bytes(#[serde(with = "serde_bytes")] Vec<u8>),
+    String(String),
+    Tuple((Struct, Struct)),
+    TupleVariant(Struct, Struct),
+    TupleVariantBytes(Struct, Struct, #[serde(with = "serde_bytes")] Vec<u8>),
+    StructVariant {
+        x: Struct,
+        y: Struct,
+    },
+    StructVariantBytes {
+        x: Struct,
+        y: Struct,
+        #[serde(with = "serde_bytes")]
+        z: Vec<u8>,
+    },
+}
+
+#[derive(Debug, PartialEq, Arbitrary, Serialize, Deserialize)]
+struct Struct {
+    a: Box<AllEnums>,
+    b: Box<AllEnums>,
+}
+
+/// Workaround https://github.com/rust-fuzz/arbitrary/issues/144
+#[derive(Debug)]
+struct Input<'i>(AllEnums, &'i [u8]);
+
+impl<'i> Arbitrary<'i> for Input<'i> {
+    fn arbitrary(u: &mut Unstructured<'i>) -> Result<Self, arbitrary::Error> {
+        Ok(Self(AllEnums::arbitrary(u)?, Arbitrary::arbitrary(u)?))
+    }
+
+    fn arbitrary_take_rest(mut u: Unstructured<'i>) -> Result<Self, arbitrary::Error> {
+        Ok(Self(
+            AllEnums::arbitrary(&mut u)?,
+            Arbitrary::arbitrary_take_rest(u)?,
+        ))
+    }
+    fn size_hint(_depth: usize) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+
+fuzz_target!(|data: Input<'_>| {
+    let bytes = data.1;
+    let data = data.0;
+    let _res: Option<AllEnums> = cbor_smol::cbor_deserialize(&bytes).ok();
+    let mut buffer = vec![0; 1024 * 20];
+    let res = cbor_smol::cbor_serialize(&data, &mut buffer).unwrap();
+    cbor_smol::cbor_deserialize(&res)
+        .map(|b: AllEnums| {
+            assert_eq!(data, b);
+        })
+        .map_err(|err| {
+            let v: Result<serde_cbor::Value, _> = serde_cbor::from_slice(&res);
+            panic!(
+                "Failed to deserialize: {:?}\n\
+            input: {:#?}\n\
+            data: {:02x?}\n\
+            serde_cbor gives: {:#?}\n",
+                err, data, res, v
+            );
+        })
+        .ok();
+});

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,19 @@
+pub const MAJOR_OFFSET: u8 = 5;
+
+pub const MAJOR_POSINT: u8 = 0;
+pub const MAJOR_NEGINT: u8 = 1;
+pub const MAJOR_BYTES: u8 = 2;
+pub const MAJOR_STR: u8 = 3;
+pub const MAJOR_ARRAY: u8 = 4;
+pub const MAJOR_MAP: u8 = 5;
+pub const MAJOR_SIMPLE: u8 = 7;
+
+pub const SIMPLE_FALSE: u8 = 20;
+pub const SIMPLE_TRUE: u8 = 21;
+pub const SIMPLE_NULL: u8 = 22;
+// pub const SIMPLE_UNDEFINED: u8 = 23;
+
+pub const VALUE_FALSE: u8 = (MAJOR_SIMPLE << MAJOR_OFFSET) | SIMPLE_FALSE;
+pub const VALUE_TRUE: u8 = (MAJOR_SIMPLE << MAJOR_OFFSET) | SIMPLE_TRUE;
+pub const VALUE_NULL: u8 = (MAJOR_SIMPLE << MAJOR_OFFSET) | SIMPLE_NULL;
+// pub const VALUE_UNDEFINED: u8 = (MAJOR_SIMPLE << MAJOR_LEN) | SIMPLE_UNDEFINED;

--- a/src/de.rs
+++ b/src/de.rs
@@ -62,7 +62,7 @@ impl<'de> Deserializer<'de> {
     }
 
     fn peek_major(&mut self) -> Result<u8> {
-        if self.input.len() != 0 {
+        if !self.input.is_empty() {
             let byte = self.input[0];
             Ok(byte >> 5)
         } else {
@@ -71,7 +71,7 @@ impl<'de> Deserializer<'de> {
     }
 
     fn peek(&mut self) -> Result<u8> {
-        if self.input.len() != 0 {
+        if !self.input.is_empty() {
             Ok(self.input[0])
         } else {
             Err(Error::DeserializeUnexpectedEnd)
@@ -79,7 +79,7 @@ impl<'de> Deserializer<'de> {
     }
 
     fn consume(&mut self) -> Result<()> {
-        if self.input.len() != 0 {
+        if !self.input.is_empty() {
             self.input = &self.input[1..];
             Ok(())
         } else {
@@ -148,7 +148,7 @@ impl<'de> Deserializer<'de> {
                 );
                 match unsigned {
                     0..=65535 => Err(Error::DeserializeNonMinimal),
-                    unsigned => Ok(unsigned as u32),
+                    unsigned => Ok(unsigned),
                 }
             }
             _ => Err(Error::DeserializeBadU32),

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,8 +1,6 @@
 use serde::Deserialize;
 
-use serde::de::{
-    IntoDeserializer,
-};
+use serde::de::IntoDeserializer;
 
 use super::error::{Error, Result};
 
@@ -36,11 +34,7 @@ where
 
 use core::convert::TryInto;
 
-use serde::de::{
-    self,
-    DeserializeSeed,
-    Visitor,
-};
+use serde::de::{self, DeserializeSeed, Visitor};
 
 /// A structure for deserializing a cbor-smol message.
 pub struct Deserializer<'de> {
@@ -104,24 +98,20 @@ impl<'de> Deserializer<'de> {
     }
 
     // TODO: name something like "one-byte-integer"
-    fn raw_deserialize_u8(&mut self, major: u8) -> Result<u8>
-    {
+    fn raw_deserialize_u8(&mut self, major: u8) -> Result<u8> {
         let additional = self.expect_major(major)?;
 
         match additional {
             byte @ 0..=23 => Ok(byte),
-            24 => {
-                match self.try_take_n(1)?[0] {
-                    0..=23 => Err(Error::DeserializeNonMinimal),
-                    byte => Ok(byte),
-                }
+            24 => match self.try_take_n(1)?[0] {
+                0..=23 => Err(Error::DeserializeNonMinimal),
+                byte => Ok(byte),
             },
             _ => Err(Error::DeserializeBadU8),
         }
     }
 
-    fn raw_deserialize_u16(&mut self, major: u8) -> Result<u16>
-    {
+    fn raw_deserialize_u16(&mut self, major: u8) -> Result<u16> {
         let number = self.raw_deserialize_u32(major)?;
         if number <= u16::max_value() as u32 {
             Ok(number as u16)
@@ -130,38 +120,37 @@ impl<'de> Deserializer<'de> {
         }
     }
 
-    fn raw_deserialize_u32(&mut self, major: u8) -> Result<u32>
-    {
+    fn raw_deserialize_u32(&mut self, major: u8) -> Result<u32> {
         let additional = self.expect_major(major)?;
 
         match additional {
             byte @ 0..=23 => Ok(byte as u32),
-            24 => {
-                match self.try_take_n(1)?[0] {
-                    0..=23 => Err(Error::DeserializeNonMinimal),
-                    byte => Ok(byte as u32),
-                }
+            24 => match self.try_take_n(1)?[0] {
+                0..=23 => Err(Error::DeserializeNonMinimal),
+                byte => Ok(byte as u32),
             },
             25 => {
                 let unsigned = u16::from_be_bytes(
                     self.try_take_n(2)?
-                    .try_into().map_err(|_| Error::InexistentSliceToArrayError)?
+                        .try_into()
+                        .map_err(|_| Error::InexistentSliceToArrayError)?,
                 );
                 match unsigned {
                     0..=255 => Err(Error::DeserializeNonMinimal),
                     unsigned => Ok(unsigned as u32),
                 }
-            },
+            }
             26 => {
                 let unsigned = u32::from_be_bytes(
                     self.try_take_n(4)?
-                    .try_into().map_err(|_| Error::InexistentSliceToArrayError)?
+                        .try_into()
+                        .map_err(|_| Error::InexistentSliceToArrayError)?,
                 );
                 match unsigned {
                     0..=65535 => Err(Error::DeserializeNonMinimal),
                     unsigned => Ok(unsigned as u32),
                 }
-            },
+            }
             _ => Err(Error::DeserializeBadU32),
         }
     }
@@ -195,7 +184,7 @@ impl<'a, 'b: 'a> serde::de::SeqAccess<'b> for SeqAccess<'a, 'b> {
 
     fn next_element_seed<V>(&mut self, seed: V) -> Result<Option<V::Value>>
     where
-        V: DeserializeSeed<'b>
+        V: DeserializeSeed<'b>,
     {
         if self.len > 0 {
             self.len -= 1;
@@ -220,7 +209,7 @@ impl<'a, 'b: 'a> serde::de::MapAccess<'b> for MapAccess<'a, 'b> {
 
     fn next_key_seed<V>(&mut self, seed: V) -> Result<Option<V::Value>>
     where
-        V: DeserializeSeed<'b>
+        V: DeserializeSeed<'b>,
     {
         if self.len > 0 {
             self.len -= 1;
@@ -317,7 +306,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 } else {
                     Err(Error::DeserializeBadI8)
                 }
-            },
+            }
             1 => {
                 let raw_u8 = self.raw_deserialize_u8(1)?;
                 // if raw_u8 <= 1 + i8::max_value() as u8 {
@@ -326,7 +315,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 } else {
                     Err(Error::DeserializeBadI8)
                 }
-            },
+            }
             _ => Err(Error::DeserializeBadI8),
         }
     }
@@ -343,7 +332,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 } else {
                     Err(Error::DeserializeBadI16)
                 }
-            },
+            }
             1 => {
                 let raw = self.raw_deserialize_u16(1)?;
                 if raw <= i16::max_value() as u16 {
@@ -351,7 +340,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 } else {
                     Err(Error::DeserializeBadI16)
                 }
-            },
+            }
             _ => Err(Error::DeserializeBadI16),
         }
     }
@@ -373,7 +362,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 } else {
                     Err(Error::DeserializeBadI32)
                 }
-            },
+            }
             _ => Err(Error::DeserializeBadI16),
         }
     }
@@ -503,7 +492,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 self.consume()?;
                 visitor.visit_unit()
             }
-            _ => Err(Error::DeserializeExpectedNull)
+            _ => Err(Error::DeserializeExpectedNull),
         }
     }
 
@@ -595,7 +584,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     // {
     //     todo!("implement `deserialize_enum`");
     // }
-
 
     // fn parse_enum<V>(&mut self, mut len: usize, visitor: V) -> Result<V::Value>
     // where
@@ -791,7 +779,7 @@ mod tests {
 
     // use crate::serde::{cbor_serialize, cbor_serialize2, cbor_deserialize};
     // use crate::serde::{cbor_serialize, cbor_serialize_old, cbor_deserialize};
-    use crate::{cbor_serialize, cbor_deserialize};
+    use crate::{cbor_deserialize, cbor_serialize};
 
     #[test]
     fn de_bool() {
@@ -829,7 +817,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn de_u16() {
         let mut buf = [0u8; 64];
@@ -858,7 +845,7 @@ mod tests {
     fn de_u32() {
         let mut buf = [0u8; 64];
 
-        for number in 0..=3*(u16::max_value() as u32) {
+        for number in 0..=3 * (u16::max_value() as u32) {
             println!("testing {}", number);
             let _n = cbor_serialize(&number, &mut buf).unwrap();
             let de: u32 = from_bytes(&buf).unwrap();
@@ -883,7 +870,7 @@ mod tests {
         let de: i32 = from_bytes(ser).unwrap();
         assert_eq!(de, number);
 
-        for number in (3*i16::min_value() as i32)..=3*(i16::max_value() as i32) {
+        for number in (3 * i16::min_value() as i32)..=3 * (i16::max_value() as i32) {
             println!("testing {}", number);
             let ser = cbor_serialize(&number, &mut buf).unwrap();
             let de: i32 = from_bytes(ser).unwrap();
@@ -913,7 +900,7 @@ mod tests {
         let bytes = crate::Bytes::<64>::from_slice(slice).unwrap();
         let ser = cbor_serialize(&bytes, &mut buf).unwrap();
         println!("serialized bytes = {:?}", ser);
-        let de: crate::Bytes::<64> = from_bytes(&buf).unwrap();
+        let de: crate::Bytes<64> = from_bytes(&buf).unwrap();
         println!("deserialized bytes = {:?}", &de);
         assert_eq!(&de, slice);
     }
@@ -976,7 +963,6 @@ mod tests {
 
     #[test]
     fn de_enum() {
-
         let mut buf = [0u8; 64];
         let e = Some(3);
         let ser = cbor_serialize(&e, &mut buf).unwrap();
@@ -984,7 +970,11 @@ mod tests {
         let de: Option<u8> = cbor_deserialize(ser).unwrap();
         assert_eq!(de, e);
         let e: Option<u8> = None;
-        println!("ser({:?}) = {:x?}", &e, cbor_serialize(&e, &mut buf).unwrap());
+        println!(
+            "ser({:?}) = {:x?}",
+            &e,
+            cbor_serialize(&e, &mut buf).unwrap()
+        );
 
         // let mut buf = [0u8; 64];
         // let _n = cbor_serialize(&None, &mut buf).unwrap();
@@ -992,7 +982,7 @@ mod tests {
 
         // use serde_indexed::{DeserializeIndexed, SerializeIndexed};
         use serde::{Deserialize, Serialize};
-        #[derive(Clone,Debug,Eq,PartialEq,Serialize,Deserialize)]
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
         pub enum Enum {
             Alpha(u8),
             // Beta((i32, u32)),
@@ -1008,7 +998,7 @@ mod tests {
         let de: Enum = cbor_deserialize(ser).unwrap();
         assert_eq!(de, e);
 
-        #[derive(Clone,Debug,Eq,PartialEq,Serialize,Deserialize)]
+        #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
         pub enum SimpleEnum {
             // Alpha(u8),
             Alpha(u8),

--- a/src/de.rs
+++ b/src/de.rs
@@ -248,10 +248,10 @@ impl<'de, 'a> serde::de::VariantAccess<'de> for &'a mut Deserializer<'de> {
 
     fn struct_variant<V: Visitor<'de>>(
         self,
-        fields: &'static [&'static str],
+        _fields: &'static [&'static str],
         visitor: V,
     ) -> Result<V::Value> {
-        serde::de::Deserializer::deserialize_tuple(self, fields.len(), visitor)
+        serde::de::Deserializer::deserialize_map(self, visitor)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -98,7 +98,7 @@ impl Display for Error {
                 DeserializeNonMinimal => "Value may be valid, but not encoded in minimal way",
                 SerdeSerCustom => "Serde Serialization Error",
                 SerdeDeCustom => "Serde Deserialization Error",
-                SerdeMissingField => "Serde Missing Required Field"
+                SerdeMissingField => "Serde Missing Required Field",
             }
         )
     }
@@ -132,7 +132,7 @@ impl serde::de::Error for Error {
         //
         // `invalid length 297, expected a sequence`
         //
-        info_now!("deser error: {}",&msg);
+        info_now!("deser error: {}", &msg);
         Error::SerdeDeCustom
     }
     fn missing_field(field: &'static str) -> Self {

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,8 @@ pub enum Error {
     DeserializeBadU16,
     /// Expected a u32
     DeserializeBadU32,
+    /// Expected a u64
+    DeserializeBadU64,
     /// Expected a NULL marker
     DeserializeExpectedNull,
     /// Inexistent slice-to-array cast error. Used here to avoid calling unwrap.
@@ -93,6 +95,7 @@ impl Display for Error {
                 DeserializeBadU8 => "Expected a u8",
                 DeserializeBadU16 => "Expected a u16",
                 DeserializeBadU32 => "Expected a u32",
+                DeserializeBadU64 => "Expected a u64",
                 DeserializeExpectedNull => "Expected 0xf6",
                 InexistentSliceToArrayError => "",
                 DeserializeNonMinimal => "Value may be valid, but not encoded in minimal way",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@ pub use error::{Error, Result};
 // pub use de::take_from_bytes;
 
 // kudos to postcard, this is much nicer than returning size
-pub fn cbor_serialize<'a, 'b, T: serde::Serialize>(
-    object: &'a T,
-    buffer: &'b mut [u8],
-) -> Result<&'b [u8]> {
+pub fn cbor_serialize<'a, T: serde::Serialize>(
+    object: &T,
+    buffer: &'a mut [u8],
+) -> Result<&'a [u8]> {
     let writer = ser::SliceWriter::new(buffer);
     let mut ser = ser::Serializer::new(writer);
 
@@ -32,9 +32,9 @@ pub fn cbor_serialize<'a, 'b, T: serde::Serialize>(
 }
 
 /// Append serialization of object to existing bytes, returning length of serialized object.
-pub fn cbor_serialize_extending_bytes<'a, 'b, T: serde::Serialize, const N: usize>(
-    object: &'a T,
-    bytes: &'b mut Bytes<N>,
+pub fn cbor_serialize_extending_bytes<T: serde::Serialize, const N: usize>(
+    object: &T,
+    bytes: &mut Bytes<N>,
 ) -> Result<usize> {
     let len_before = bytes.len();
     let mut ser = ser::Serializer::new(bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ generate_macros!();
 
 pub use heapless_bytes::Bytes;
 
+pub(crate) mod consts;
 pub mod de;
 pub mod error;
 pub mod ser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,8 +7,8 @@ generate_macros!();
 pub use heapless_bytes::Bytes;
 
 pub mod de;
-pub mod ser;
 pub mod error;
+pub mod ser;
 
 pub use error::{Error, Result};
 
@@ -31,7 +31,6 @@ pub fn cbor_serialize<'a, 'b, T: serde::Serialize>(
     Ok(&buffer[..size])
 }
 
-
 /// Append serialization of object to existing bytes, returning length of serialized object.
 pub fn cbor_serialize_extending_bytes<'a, 'b, T: serde::Serialize, const N: usize>(
     object: &'a T,
@@ -45,7 +44,6 @@ pub fn cbor_serialize_extending_bytes<'a, 'b, T: serde::Serialize, const N: usiz
     Ok(ser.into_inner().len() - len_before)
 }
 
-
 /// Serialize object into newly allocated Bytes.
 pub fn cbor_serialize_bytes<T: serde::Serialize, const N: usize>(object: &T) -> Result<Bytes<N>> {
     let mut data = Bytes::<N>::new();
@@ -53,11 +51,7 @@ pub fn cbor_serialize_bytes<T: serde::Serialize, const N: usize>(object: &T) -> 
     Ok(data)
 }
 
-
-pub fn cbor_deserialize<'de, T: serde::Deserialize<'de>>(
-    buffer: &'de [u8],
-) -> Result<T> {
+pub fn cbor_deserialize<'de, T: serde::Deserialize<'de>>(buffer: &'de [u8]) -> Result<T> {
     // cortex_m_semihosting::hprintln!("deserializing {:?}", buffer).ok();
     de::from_bytes(buffer)
 }
-

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -2,6 +2,8 @@ use super::error::{Error, Result};
 use serde::ser;
 use serde::Serialize;
 
+use crate::consts::*;
+
 // pub fn to_slice<'a, 'b, T>(value: &'a T, buf: &'b mut [u8]) -> Result<&'b mut [u8]>
 // where
 //     T: Serialize + ?Sized,
@@ -90,9 +92,9 @@ impl<W: Writer> Serializer<W> {
     #[inline]
     fn write_u8(&mut self, major: u8, value: u8) -> Result<()> {
         if value <= 0x17 {
-            self.writer.write_all(&[major << 5 | value])
+            self.writer.write_all(&[major << MAJOR_OFFSET | value])
         } else {
-            let buf = [major << 5 | 24, value];
+            let buf = [major << MAJOR_OFFSET | 24, value];
             self.writer.write_all(&buf)
         }
         .map_err(|e| e.into())
@@ -103,7 +105,7 @@ impl<W: Writer> Serializer<W> {
         if value <= u16::from(u8::max_value()) {
             self.write_u8(major, value as u8)
         } else {
-            let mut buf = [major << 5 | 25, 0, 0];
+            let mut buf = [major << MAJOR_OFFSET | 25, 0, 0];
             buf[1..].copy_from_slice(&value.to_be_bytes());
             self.writer.write_all(&buf).map_err(|e| e.into())
         }
@@ -114,7 +116,7 @@ impl<W: Writer> Serializer<W> {
         if value <= u32::from(u16::max_value()) {
             self.write_u16(major, value as u16)
         } else {
-            let mut buf = [major << 5 | 26, 0, 0, 0, 0];
+            let mut buf = [major << MAJOR_OFFSET | 26, 0, 0, 0, 0];
             buf[1..].copy_from_slice(&value.to_be_bytes());
             self.writer.write_all(&buf).map_err(|e| e.into())
         }
@@ -125,7 +127,7 @@ impl<W: Writer> Serializer<W> {
         if value <= u64::from(u32::max_value()) {
             self.write_u32(major, value as u32)
         } else {
-            let mut buf = [major << 5 | 27, 0, 0, 0, 0, 0, 0, 0, 0];
+            let mut buf = [major << MAJOR_OFFSET | 27, 0, 0, 0, 0, 0, 0, 0, 0];
             buf[1..].copy_from_slice(&value.to_be_bytes());
             self.writer.write_all(&buf).map_err(|e| e.into())
         }
@@ -144,7 +146,7 @@ impl<W: Writer> Serializer<W> {
             }
             None => {
                 self.writer
-                    .write_all(&[major << 5 | 31])
+                    .write_all(&[major << MAJOR_OFFSET | 31])
                     .map_err(|e| e.into())?;
                 true
             }
@@ -183,7 +185,7 @@ where
 
     #[inline]
     fn serialize_bool(self, value: bool) -> Result<()> {
-        let value = if value { 0xf5 } else { 0xf4 };
+        let value = if value { VALUE_TRUE } else { VALUE_FALSE };
         self.writer.write_all(&[value]).map_err(|e| e.into())
     }
 
@@ -221,22 +223,22 @@ where
 
     #[inline]
     fn serialize_u8(self, value: u8) -> Result<()> {
-        self.write_u8(0, value)
+        self.write_u8(MAJOR_POSINT, value)
     }
 
     #[inline]
     fn serialize_u16(self, value: u16) -> Result<()> {
-        self.write_u16(0, value)
+        self.write_u16(MAJOR_POSINT, value)
     }
 
     #[inline]
     fn serialize_u32(self, value: u32) -> Result<()> {
-        self.write_u32(0, value)
+        self.write_u32(MAJOR_POSINT, value)
     }
 
     #[inline]
     fn serialize_u64(self, value: u64) -> Result<()> {
-        self.write_u64(0, value)
+        self.write_u64(MAJOR_POSINT, value)
     }
 
     fn serialize_f32(self, _v: f32) -> Result<()> {
@@ -256,7 +258,7 @@ where
 
     #[inline]
     fn serialize_str(self, value: &str) -> Result<()> {
-        self.write_u64(3, value.len() as u64)?;
+        self.write_u64(MAJOR_STR, value.len() as u64)?;
         self.writer
             .write_all(value.as_bytes())
             .map_err(|e| e.into())
@@ -264,13 +266,13 @@ where
 
     #[inline]
     fn serialize_bytes(self, value: &[u8]) -> Result<()> {
-        self.write_u64(2, value.len() as u64)?;
+        self.write_u64(MAJOR_BYTES, value.len() as u64)?;
         self.writer.write_all(value).map_err(|e| e.into())
     }
 
     #[inline]
     fn serialize_none(self) -> Result<()> {
-        self.writer.write_all(&[0xf6]).map_err(|e| e.into())
+        self.writer.write_all(&[VALUE_NULL]).map_err(|e| e.into())
     }
 
     #[inline]
@@ -333,7 +335,7 @@ where
         //     self.write_u64(5, 1u64)?;
         //     variant.serialize(&mut *self)?;
         // } else {
-        self.writer.write_all(&[4 << 5 | 2]).map_err(|e| e.into())?;
+        self.write_u64(MAJOR_ARRAY, 2)?;
         self.serialize_unit_variant(name, variant_index, variant)?;
         // }
         value.serialize(self)
@@ -341,12 +343,12 @@ where
 
     #[inline]
     fn serialize_seq(self, len: Option<usize>) -> Result<CollectionSerializer<'a, W>> {
-        self.serialize_collection(4, len)
+        self.serialize_collection(MAJOR_ARRAY, len)
     }
 
     #[inline]
     fn serialize_tuple(self, len: usize) -> Result<&'a mut Serializer<W>> {
-        self.write_u64(4, len as u64)?;
+        self.write_u64(MAJOR_ARRAY, len as u64)?;
         Ok(self)
     }
 
@@ -372,7 +374,7 @@ where
         //     variant.serialize(&mut *self)?;
         //     self.serialize_tuple(len)
         // } else {
-        self.write_u64(4, (len + 1) as u64)?;
+        self.write_u64(MAJOR_ARRAY, (len + 1) as u64)?;
         self.serialize_unit_variant(name, variant_index, variant)?;
         Ok(self)
         // }
@@ -380,7 +382,7 @@ where
 
     #[inline]
     fn serialize_map(self, len: Option<usize>) -> Result<CollectionSerializer<'a, W>> {
-        self.serialize_collection(5, len)
+        self.serialize_collection(MAJOR_MAP, len)
     }
 
     // #[cfg(not(feature = "std"))]
@@ -398,7 +400,7 @@ where
 
     #[inline]
     fn serialize_struct(self, _name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
-        self.write_u64(5, len as u64)?;
+        self.write_u64(MAJOR_MAP, len as u64)?;
         Ok(self)
     }
 
@@ -413,7 +415,7 @@ where
         // if self.enum_as_map {
         //     self.write_u64(5, 1u64)?;
         // } else {
-        self.writer.write_all(&[4 << 5 | 2]).map_err(|e| e.into())?;
+        self.write_u64(MAJOR_ARRAY, 2)?;
         // }
         self.serialize_unit_variant(name, variant_index, variant)?;
         self.serialize_struct(name, len)

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -132,11 +132,11 @@ impl<W: Writer> Serializer<W> {
     }
 
     #[inline]
-    fn serialize_collection<'a>(
-        &'a mut self,
+    fn serialize_collection(
+        &mut self,
         major: u8,
         len: Option<usize>,
-    ) -> Result<CollectionSerializer<'a, W>> {
+    ) -> Result<CollectionSerializer<'_, W>> {
         let needs_eof = match len {
             Some(len) => {
                 self.write_u64(major, len as u64)?;

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -1,6 +1,6 @@
-use serde::Serialize;
-use serde::ser;
 use super::error::{Error, Result};
+use serde::ser;
+use serde::Serialize;
 
 // pub fn to_slice<'a, 'b, T>(value: &'a T, buf: &'b mut [u8]) -> Result<&'b mut [u8]>
 // where
@@ -55,13 +55,12 @@ impl<'a> Writer for SliceWriter<'a> {
     }
 }
 
-impl<'a, const N: usize> Writer for &'a mut crate::Bytes<N>
-{
+impl<'a, const N: usize> Writer for &'a mut crate::Bytes<N> {
     type Error = Error;
 
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
-        self.extend_from_slice(buf).map_err(
-            |_| Error::SerializeBufferFull(buf.len()))
+        self.extend_from_slice(buf)
+            .map_err(|_| Error::SerializeBufferFull(buf.len()))
     }
 }
 
@@ -73,7 +72,6 @@ pub struct Serializer<W>
 }
 
 impl<W: Writer> Serializer<W> {
-
     #[inline]
     pub fn new(writer: W) -> Self {
         Serializer {
@@ -181,8 +179,7 @@ where
     type SerializeTupleVariant = &'a mut Serializer<W>;
     type SerializeMap = CollectionSerializer<'a, W>;
     type SerializeStruct = &'a mut Serializer<W>;
-    type SerializeStructVariant= &'a mut Serializer<W>;
-
+    type SerializeStructVariant = &'a mut Serializer<W>;
 
     #[inline]
     fn serialize_bool(self, value: bool) -> Result<()> {
@@ -302,18 +299,14 @@ where
         _variant: &'static str,
     ) -> Result<()> {
         // if self.packed {
-            self.serialize_u32(variant_index)
+        self.serialize_u32(variant_index)
         // } else {
         //     self.serialize_str(variant)
         // }
     }
 
     #[inline]
-    fn serialize_newtype_struct<T>(
-        self,
-        _name: &'static str,
-        value: &T,
-    ) -> Result<()>
+    fn serialize_newtype_struct<T>(self, _name: &'static str, value: &T) -> Result<()>
     where
         T: ?Sized + ser::Serialize,
     {
@@ -340,8 +333,8 @@ where
         //     self.write_u64(5, 1u64)?;
         //     variant.serialize(&mut *self)?;
         // } else {
-            self.writer.write_all(&[4 << 5 | 2]).map_err(|e| e.into())?;
-            self.serialize_unit_variant(name, variant_index, variant)?;
+        self.writer.write_all(&[4 << 5 | 2]).map_err(|e| e.into())?;
+        self.serialize_unit_variant(name, variant_index, variant)?;
         // }
         value.serialize(self)
     }
@@ -379,9 +372,9 @@ where
         //     variant.serialize(&mut *self)?;
         //     self.serialize_tuple(len)
         // } else {
-            self.write_u64(4, (len + 1) as u64)?;
-            self.serialize_unit_variant(name, variant_index, variant)?;
-            Ok(self)
+        self.write_u64(4, (len + 1) as u64)?;
+        self.serialize_unit_variant(name, variant_index, variant)?;
+        Ok(self)
         // }
     }
 
@@ -420,7 +413,7 @@ where
         // if self.enum_as_map {
         //     self.write_u64(5, 1u64)?;
         // } else {
-            self.writer.write_all(&[4 << 5 | 2]).map_err(|e| e.into())?;
+        self.writer.write_all(&[4 << 5 | 2]).map_err(|e| e.into())?;
         // }
         self.serialize_unit_variant(name, variant_index, variant)?;
         self.serialize_struct(name, len)
@@ -551,7 +544,7 @@ where
     }
 }
 
-impl<'a, W> ser::SerializeStructVariant for  &'a mut Serializer<W>
+impl<'a, W> ser::SerializeStructVariant for &'a mut Serializer<W>
 where
     W: Writer,
 {


### PR DESCRIPTION
This patch runs cargo fmt, fixes cilppy warnings, fixes a bug preventing the deserialization of enums with struct variants, and a bug affecting tuple variants.

It also adds some basic fuzzing infrastructure, which didn't find any crash (outside of the ones fixed by this PR) in 20min

- struct like variants of enums were deserialized as tuples instead of maps
- tuple-like enums were not supported
- u64 were deserialized as u32, which meant some data would not deserialize properly