### PR TITLE
Add support for `deserialize_ignored_any`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1", default-features = false }
 [dev-dependencies]
 heapless = { version = "0.7", features = ["serde"] }
 serde = { version = "1", default-features = false, features = ["derive"] }
+serde_bytes = "0.11.12"
 
 [features]
 log-all = []

--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -12,8 +12,7 @@ enum AllEnums {
     U16(u16),
     I32(i32),
     U32(u32),
-    // Not implemented
-    // I64(i64),
+    I64(i64),
     U64(u64),
     Struct(Struct),
     Array([Struct; 4]),

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -7,6 +7,7 @@ pub const MAJOR_STR: u8 = 3;
 pub const MAJOR_ARRAY: u8 = 4;
 pub const MAJOR_MAP: u8 = 5;
 pub const MAJOR_SIMPLE: u8 = 7;
+pub const MAJOR_FLOAT: u8 = 7;
 
 pub const SIMPLE_FALSE: u8 = 20;
 pub const SIMPLE_TRUE: u8 = 21;

--- a/src/de.rs
+++ b/src/de.rs
@@ -262,18 +262,17 @@ impl<'de> Deserializer<'de> {
     }
 
     fn ignore(&mut self) -> Result<()> {
-        match self.peek_major()? {
-            0 => self.ignore_int(0)?,
-            1 => self.ignore_int(1)?,
-            2 => self.ignore_bytes(2)?,
-            3 => self.ignore_bytes(3)?,
-            4 => self.ignore_array(4, 1)?,
-            5 => self.ignore_array(5, 2)?,
+        let major = self.peek_major()?;
+        match major {
+            MAJOR_POSINT | MAJOR_NEGINT => self.ignore_int(major)?,
+            MAJOR_BYTES | MAJOR_STR => self.ignore_bytes(major)?,
+            MAJOR_ARRAY => self.ignore_array(MAJOR_ARRAY, 1)?,
+            MAJOR_MAP => self.ignore_array(MAJOR_MAP, 2)?,
             6 => {
                 self.ignore_int(6)?;
                 self.ignore()?;
             }
-            7 => self.ignore_float()?,
+            MAJOR_FLOAT => self.ignore_float()?,
             _ => return Err(Error::DeserializeBadMajor),
         }
         Ok(())

--- a/src/de.rs
+++ b/src/de.rs
@@ -229,9 +229,12 @@ impl<'de> Deserializer<'de> {
         Ok(())
     }
 
-    fn ignore_array(&mut self, major: u8, mult: u32) -> Result<()> {
-        let length = self.raw_deserialize_u32(major)?;
-        for _ in 0..length * mult {
+    fn ignore_array(&mut self, major: u8, mult: usize) -> Result<()> {
+        let length = self.raw_deserialize_u32(major)? as usize;
+        let Some(real_length) = length.checked_mul(mult) else {
+            return Err(Error::InexistentSliceToArrayError);
+        };
+        for _ in 0..real_length {
             self.ignore()?;
         }
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,6 +42,8 @@ pub enum Error {
     DeserializeBadI16,
     /// Expected a i32, was too large
     DeserializeBadI32,
+    /// Expected a i64, was too large
+    DeserializeBadI64,
     /// Expected a u8
     DeserializeBadU8,
     /// Expected a u16
@@ -91,6 +93,7 @@ impl Display for Error {
                 DeserializeBadI8 => "Expected a i8",
                 DeserializeBadI16 => "Expected a i16",
                 DeserializeBadI32 => "Expected a i32",
+                DeserializeBadI64 => "Expected a i64",
                 DeserializeBadMajor => "Expected a different major type",
                 DeserializeBadU8 => "Expected a u8",
                 DeserializeBadU16 => "Expected a u16",


### PR DESCRIPTION
This PR also implements deserializing i64, which was missing and noticed during testing.

Depends on:
- #4 