### PR TITLE
Bytes deserialization: accept arrays

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_bytes = "0.11.12"
 
 [features]
+bytes-from-array = []
 log-all = []
 log-none = []
 log-info = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -599,6 +599,7 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         let major = self.peek_major()?;
         match major {
+            #[cfg(feature = "bytes-from-array")]
             MAJOR_ARRAY => {
                 let len = self.raw_deserialize_u32(MAJOR_ARRAY)?;
                 visitor.visit_seq(SeqAccess {


### PR DESCRIPTION
Deserializing bytes need to accept Arrays of integers so that something that was serialized without `serde-bytes` can still be deserialized once it is added.

Depends on:
- #6 