### PR TITLE
deserialize_identifier: add support for all types expected by  serde

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -807,9 +807,16 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         let major = self.peek_major()?;
         match major {
-            MAJOR_STR => self.deserialize_str(visitor),
+            MAJOR_BYTES | MAJOR_STR => {
+                // Rust identifiers are always valid UTF-8 so we can assume that bytes are
+                // UTF-8-encoded strings.  This has the benefit that we only need a mapping from
+                // strings to fields (and the mapping from bytes to fields can be optimized out).
+                let length = self.raw_deserialize_u32(major)? as usize;
+                let bytes: &'de [u8] = self.try_take_n(length)?;
+                let string_slice = core::str::from_utf8(bytes).map_err(|_| Error::DeserializeBadUtf8)?;
+                visitor.visit_borrowed_str(string_slice)
+            }
             MAJOR_POSINT => self.deserialize_u64(visitor),
-            MAJOR_BYTES => self.deserialize_bytes(visitor),
             _ => Err(Error::DeserializeBadMajor),
         }
     }

--- a/src/de.rs
+++ b/src/de.rs
@@ -805,7 +805,13 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     where
         V: Visitor<'de>,
     {
-        self.deserialize_str(visitor)
+        let major = self.peek_major()?;
+        match major {
+            MAJOR_STR => self.deserialize_str(visitor),
+            MAJOR_POSINT => self.deserialize_u64(visitor),
+            MAJOR_BYTES => self.deserialize_bytes(visitor),
+            _ => Err(Error::DeserializeBadMajor),
+        }
     }
 
     fn deserialize_ignored_any<V>(self, visitor: V) -> Result<V::Value>


### PR DESCRIPTION
The default serde deserialize derive accepts 3 types for identifiers:

- The name of the field as `str`
- The name of the field as ascii bytes
- The index of the field as u64

This PR changes deserialize_identifier to have compatibility with all of these
This is necessary for https://github.com/Nitrokey/fido-authenticator/issues/57,
which needs compatibility with both the str variant and the index variant

Built on top of #7 

