### PR TITLE
Never inline map value deserialization

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -342,6 +342,7 @@ impl<'a, 'b: 'a> serde::de::MapAccess<'b> for MapAccess<'a, 'b> {
         }
     }
 
+    #[inline(never)]
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
     where
         V: de::DeserializeSeed<'b>,


### PR DESCRIPTION
Inlining it means that the deserialization of basic datatypes is inlined into all deserialization functions, leading to a significant overhead.

Original PR: https://github.com/Nitrokey/cbor-smol/pull/1