### PR TITLE
Revert "Never inline map value deserialization"

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -342,7 +342,6 @@ impl<'a, 'b: 'a> serde::de::MapAccess<'b> for MapAccess<'a, 'b> {
         }
     }
 
-    #[inline(never)]
     fn next_value_seed<V>(&mut self, seed: V) -> Result<V::Value>
     where
         V: de::DeserializeSeed<'b>,


### PR DESCRIPTION
This reverts commit 6b3ce6928edd98e9a23044d54c75eaaf1f6d1e9a.

The change has been superseded by https://github.com/Nitrokey/cbor-smol/pull/4 = https://github.com/trussed-dev/cbor-smol/pull/15 so it was unnecessary to port it to upstream in https://github.com/trussed-dev/cbor-smol/pull/16.

----

Originally, we applied these optimizations to the fork:
- https://github.com/Nitrokey/cbor-smol/pull/1
- https://github.com/Nitrokey/cbor-smol/pull/4, reverting the previous change

When porting the patches to upstream, I applied them in the reverse order:
- https://github.com/trussed-dev/cbor-smol/pull/15
- https://github.com/trussed-dev/cbor-smol/pull/16

… and missed that the first patch was actually reverted by the second patch.

See this comment for the numbers: https://github.com/Nitrokey/nitrokey-3-firmware/pull/538#issuecomment-2397527793