### PR TITLE
Release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased][]
+
+[Unreleased]: https://github.com/trussed-dev/cbor-smol/compare/0.4.1...HEAD
+
+-
+
+## [0.4.1][] - 2024-10-08
+
+[0.4.1]: https://github.com/trussed-dev/cbor-smol/compare/0.4.0...0.4.1
+
+### Added
+
+- Add support for `deserialize_ignored_any` ([#6](https://github.com/trussed-dev/cbor-smol/pull/6))
+- Accept arrays of integers in `deserialize_bytes` ([#7](https://github.com/trussed-dev/cbor-smol/pull/7))
+- Add support for all types expected by serde in `deserialize_identifier` ([#8](https://github.com/trussed-dev/cbor-smol/pull/8))
+- Add `?Sized` trait bound to `cbor_serialize`, `cbor_serialize_extending_bytes` and `cbor_serialize_bytes` ([#10](https://github.com/trussed-dev/cbor-smol/pull/10))
+
+### Fixed
+
+- Fix deserialization of enums with struct variants ([#4](https://github.com/trussed-dev/cbor-smol/pull/4))
+- Never inline map and tuple deserialization ([#15](https://github.com/trussed-dev/cbor-smol/pull/15))
+
+## [0.4.0][] - 2021-06-10
+
+[0.4.0]: https://github.com/trussed-dev/cbor-smol/compare/0.3.1...0.4.0
+
+### Changed
+
+- Update `heapless` to 0.7 and `heapless-bytes` to 0.3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,15 @@
 [package]
 name = "cbor-smol"
-version = "0.4.0"
-authors = ["Nicolas Stalder <n@stalder.io>"]
+version = "0.4.1"
+authors = ["Nicolas Stalder <n@stalder.io>", "The Trussed developers"]
 edition = "2021"
 description = "Streamlined serde serializer/deserializer for CBOR"
-repository = "https://github.com/nickray/cbor-smol"
+repository = "https://github.com/trussed-dev/cbor-smol"
 readme = "README.md"
 license = "Apache-2.0 OR MIT"
 documentation = "https://docs.rs/cbor-smol"
 keywords = ["CBOR", "serde"]
 categories = ["development-tools", "embedded"]
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 delog = "0.1.0-alpha.3"
@@ -25,7 +23,6 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_bytes = "0.11.12"
 
 [features]
-bytes-from-array = []
 log-all = []
 log-none = []
 log-info = []

--- a/src/de.rs
+++ b/src/de.rs
@@ -599,7 +599,6 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
     {
         let major = self.peek_major()?;
         match major {
-            #[cfg(feature = "bytes-from-array")]
             MAJOR_ARRAY => {
                 let len = self.raw_deserialize_u32(MAJOR_ARRAY)?;
                 visitor.visit_seq(SeqAccess {


### PR DESCRIPTION
This patch also removes the bytes-from-array feature:  We originally added it to the fork so that a wrong patched version would cause a compiler error.  Now we can just bump the required minimum version instead.