### PR TITLE
Mark Error as non-exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/trussed-dev/cbor-smol/compare/0.4.1...HEAD
 
--
+- Mark `Error` as non-exhaustive ([#11](https://github.com/trussed-dev/cbor-smol/issues/11))
 
 ## [0.4.1][] - 2024-10-08
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ pub type Result<T, Err = Error> = core::result::Result<T, Err>;
 /// This is the error type used by cbor-smol
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 #[repr(u8)]
+#[non_exhaustive]
 pub enum Error {
     /// This is a feature that cbor-smol will never implement
     WontImplement,


### PR DESCRIPTION
Adding a new error variant should not be a breaking change.

Fixes: https://github.com/trussed-dev/cbor-smol/issues/11