### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
-[Unreleased]: https://github.com/trussed-dev/cbor-smol/compare/0.4.1...HEAD
+[Unreleased]: https://github.com/trussed-dev/cbor-smol/compare/0.5.0...HEAD
+
+-
+
+## [0.5.0][] - 2024-10-21
+
+[0.5.0]: https://github.com/trussed-dev/cbor-smol/compare/0.4.1...0.5.0
+
+### Changed
 
 - Mark `Error` as non-exhaustive ([#11](https://github.com/trussed-dev/cbor-smol/issues/11))
+- Add support for multiple `heapless` and `heapless-bytes` versions ([#13](https://github.com/trussed-dev/cbor-smol/pull/13)):
+  - Move existing support for `heapless` 0.7 and `heapless-bytes` 0.3 behind features
+  - Add support for `heapless` 0.8 and `heapless-bytes` 0.4
+  - Remove `cbor_serialize_bytes` and `cbor_serialize_extending_bytes` (use `cbor_serialize_to` instead)
 
 ## [0.4.1][] - 2024-10-08
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ serde = { version = "1", default-features = false, features = ["derive"] }
 serde_bytes = "0.11.12"
 
 [features]
-default = ["heapless-bytes-v0-3"]
 heapless-bytes-v0-3 = ["dep:heapless-bytes-v0-3", "heapless-v0-7"]
 heapless-bytes-v0-4 = ["dep:heapless-bytes-v0-4"]
 heapless-v0-7 = ["dep:heapless-v0-7"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,33 +34,6 @@ pub fn cbor_serialize<'a, T: ?Sized + serde::Serialize>(
     Ok(&buffer[..written])
 }
 
-#[cfg(feature = "heapless-bytes-v0-3")]
-#[deprecated(note = "use `cbor_serialize_to` instead")]
-/// Append serialization of object to existing bytes, returning length of serialized object.
-pub fn cbor_serialize_extending_bytes<T: ?Sized + serde::Serialize, const N: usize>(
-    object: &T,
-    bytes: &mut heapless_bytes_v0_3::Bytes<N>,
-) -> Result<usize> {
-    let len_before = bytes.len();
-    let vec: &mut heapless_v0_7::Vec<u8, N> = bytes;
-    let mut ser = ser::Serializer::new(vec);
-
-    object.serialize(&mut ser)?;
-
-    Ok(ser.into_inner().len() - len_before)
-}
-
-#[cfg(feature = "heapless-bytes-v0-3")]
-/// Serialize object into newly allocated Bytes.
-pub fn cbor_serialize_bytes<T: ?Sized + serde::Serialize, const N: usize>(
-    object: &T,
-) -> Result<heapless_bytes_v0_3::Bytes<N>> {
-    let mut data = heapless_bytes_v0_3::Bytes::<N>::new();
-    #[allow(deprecated)]
-    cbor_serialize_extending_bytes(object, &mut data)?;
-    Ok(data)
-}
-
 pub fn cbor_deserialize<'de, T: serde::Deserialize<'de>>(buffer: &'de [u8]) -> Result<T> {
     // cortex_m_semihosting::hprintln!("deserializing {:?}", buffer).ok();
     de::from_bytes(buffer)


### PR DESCRIPTION
@sosthene-nitrokey I’ve removed the default features and the old helper methods for heapless-bytes 0.3 for the release.  Are you okay with that?