### PR TITLE
Bump version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cbor-smol"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Nicolas Stalder <n@stalder.io>", "The Trussed developers"]
 edition = "2021"
 description = "Streamlined serde serializer/deserializer for CBOR"


### PR DESCRIPTION
I forgot to update Cargo.toml in https://github.com/trussed-dev/cbor-smol/pull/20.