### PR TITLE
Remove usize value from Error::SerializeBufferFull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/trussed-dev/cbor-smol/compare/0.5.0...HEAD
 
--
+### Changed
+
+- Remove `usize` value from `Error::SerializeBufferFull` variant
 
 ## [0.5.0][] - 2024-10-21
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,7 +15,7 @@ pub enum Error {
     /// This is a feature that cbor-smol intends to support, but does not yet
     NotYetImplemented,
     /// The serialize buffer is full
-    SerializeBufferFull(usize),
+    SerializeBufferFull,
     // /// The length of a sequence must be known
     // SerializeSeqLengthUnknown,
     /// Hit the end of buffer, expected more data
@@ -78,7 +78,7 @@ impl Display for Error {
                 NotYetImplemented => {
                     "This is a feature that cbor-smol intends to support, but does not yet"
                 }
-                SerializeBufferFull(i) => "The serialize buffer is full",
+                SerializeBufferFull => "The serialize buffer is full",
                 // SerializeSeqLengthUnknown => "The length of a sequence must be known",
                 DeserializeUnexpectedEnd => "Hit the end of buffer, expected more data",
                 // DeserializeBadVarint => {

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -20,7 +20,7 @@ impl<'a> Writer for &'a mut [u8] {
         let l = buf.len();
         if self.len() < l {
             // This buffer will not fit in our slice
-            return Err(Error::SerializeBufferFull(0));
+            return Err(Error::SerializeBufferFull);
         }
         let (current, rem) = mem::take(self).split_at_mut(l);
         current.copy_from_slice(buf);
@@ -34,7 +34,7 @@ impl<const N: usize> Writer for heapless_bytes_v0_3::Bytes<N> {
     type Error = Error;
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         self.extend_from_slice(buf)
-            .or(Err(Error::SerializeBufferFull(self.len())))
+            .or(Err(Error::SerializeBufferFull))
     }
 }
 
@@ -43,7 +43,7 @@ impl<const N: usize> Writer for heapless_bytes_v0_4::Bytes<N> {
     type Error = Error;
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         self.extend_from_slice(buf)
-            .or(Err(Error::SerializeBufferFull(self.len())))
+            .or(Err(Error::SerializeBufferFull))
     }
 }
 
@@ -52,7 +52,7 @@ impl<const N: usize> Writer for heapless_v0_7::Vec<u8, N> {
     type Error = Error;
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         self.extend_from_slice(buf)
-            .or(Err(Error::SerializeBufferFull(self.len())))
+            .or(Err(Error::SerializeBufferFull))
     }
 }
 
@@ -61,7 +61,7 @@ impl<const N: usize> Writer for heapless_v0_8::Vec<u8, N> {
     type Error = Error;
     fn write_all(&mut self, buf: &[u8]) -> Result<()> {
         self.extend_from_slice(buf)
-            .or(Err(Error::SerializeBufferFull(self.len())))
+            .or(Err(Error::SerializeBufferFull))
     }
 }
 


### PR DESCRIPTION
The value is not used (and actually does not provide much insight) but bloats the error enum – just removing it yields a ~ 5k binary size increase on nitrokey-3-firmware.